### PR TITLE
Fix ERA5 dataset link in training documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ xarray utilities. See the per-model READMEs for model-specific code.
 ### Training Data
 
 Full model training requires downloading the
-[ERA5](https://www.ecmwf.int/en/forecasts/datasets/reanalysis-datasets/era5)
+[ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5)
 dataset from [ECMWF](https://www.ecmwf.int/), best accessed as Zarr via
 [WeatherBench2](https://weatherbench2.readthedocs.io/en/latest/data-guide.html#era5).
 


### PR DESCRIPTION
## Summary

Update the README's retired ERA5 dataset URL to ECMWF's current "ECMWF Reanalysis v5 (ERA5)" page without changing the surrounding training-data guidance.

Closes #71

## Validation

- confirmed the old URL is absent from `README.md`
- confirmed the replacement URL appears exactly once
- verified the replacement resolves to ECMWF's ERA5 dataset page through ECMWF's indexed page metadata
- `git diff --check`
